### PR TITLE
fix(recursion): fix recursion issue with followVars

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const varRgx = /^[@$]/;
 const followVar = (value, lessVars, dictionary) => {
   if (varRgx.test(value)) {
     // value is a variable
-    return followVar(lessVars[value] || dictionary[value.replace(varRgx, '')]);
+    return followVar(lessVars[value] || dictionary[value.replace(varRgx, '')], lessVars, dictionary);
   }
   return value;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -157,3 +157,15 @@ it('should support sass variables with stripPrefix', () => expect(lessVarsToJS(`
   'font-stack': 'Helvetica, sans-serif',
   'primary-color': '#333'
 }));
+
+it('should recursively call followVar', () => expect(lessVarsToJS(`
+  @klm:    @hij;
+  @abc:    '#fff';
+  @def:    @abc;
+  @hij:    @def;
+`, { stripPrefix: true, resolveVariables: true })).to.deep.equal({
+  abc: '#fff',
+  def: '#fff',
+  hij: '#fff',
+  klm: '#fff'
+}));


### PR DESCRIPTION
There was an issue where followVar was recursively being called,
but we lost the lessVars and dictionary objects.

Adding the objects on the call fixed the issue.
I wrote a failing test and fixed it.